### PR TITLE
Fix horizontal scrolling when content is too wide

### DIFF
--- a/src/components/App.css
+++ b/src/components/App.css
@@ -11,7 +11,6 @@ body {
 }
 
 .App-Body {
-  padding: 0px 100px 100px 100px;
   flex-grow: 1;
   overflow-y: scroll;
 }

--- a/src/components/Table.css
+++ b/src/components/Table.css
@@ -89,8 +89,8 @@ th {
   word-wrap: break-word;
   text-overflow: ellipsis;
   overflow: hidden;
-  white-space: nowrap;
   max-width: 770px;
+  min-width: auto;
 }
 
 .bugs-table .bug-alias {


### PR DESCRIPTION
A fix for Issue #22, where lengthy bug summaries would cause a horizontal scroll bar to appear for the bugs table, especially at narrower browser widths.


### Summary of Changes
- Remove padding from `app-body` in `App.css` to allow table to shift to one side and remain in view as the browser width is decreased. 
- Add `min-width: auto` attribute to `App.css` to allow the table content to collapse slightly as browser width is decreased.
- Remove `white-space: no-wrap` attribute from `Table.css` to allow lengthy bug summaries to wrap as browser width is decreased.