### PR TITLE
Fix metas header

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -243,7 +243,7 @@ class Header extends React.Component {
     const metasPage = page == 'metas';
 
     if (metasPage) {
-      return `${metas.length} Metas`;
+      return <h1>{`${metas.length} Metas`}</h1>;
     }
 
     let term = '';


### PR DESCRIPTION
A fix for Issue #34, where the "Metas" header would display with improper formatting. 

### Summary of Changes
- Added `<h1>` tags to the Metas header text that is returned from the `GetTitle` function within `Header.js`. 